### PR TITLE
feat(popover): add 'appendTo' and 'zIndex' optional properties

### DIFF
--- a/src/app/ui/popover/helpers.ts
+++ b/src/app/ui/popover/helpers.ts
@@ -106,7 +106,9 @@ export function combineOptionsAndDefaults(providedConfig: PopoverConfig, options
     horizontalAlignment: options.horizontalAlignment || defaultOptions.horizontalAlignment,
     shouldClose: options.shouldClose || (() => { }),
     popoverPosition: options.popoverPosition || (() => { }),
-    horizontal: options.hasOwnProperty('horizontal') ? options.horizontal : defaultOptions.horizontal
+    horizontal: options.hasOwnProperty('horizontal') ? options.horizontal : defaultOptions.horizontal,
+    appendTo: options.appendTo ? options.appendTo : document.body,
+    zIndex: options.zIndex
   };
   return result;
 }

--- a/src/app/ui/popover/popover-options.interface.ts
+++ b/src/app/ui/popover/popover-options.interface.ts
@@ -8,6 +8,8 @@ export interface PopoverOptions {
   scrollMaskClass?: string;
   escToClose?: boolean;
   clickOutsideToClose?: boolean;
+  appendTo?: HTMLElement;
+  zIndex?: number;
   shouldClose?: () => void;
   popoverPosition?: (p: PopoverPosition) => void;
 }

--- a/src/app/ui/popover/popover.service.ts
+++ b/src/app/ui/popover/popover.service.ts
@@ -189,9 +189,16 @@ export class PopoverService {
       addClasses(container, options.popoverClass);
       addClasses(scrollMask, options.scrollMaskClass);
       addClasses(arrowElement, options.arrowClass);
-      document.body.appendChild(container);
-      document.body.appendChild(arrowElement);
-      document.body.appendChild(scrollMask);
+
+      if (options.zIndex) {
+        container.style.zIndex = options.zIndex.toString();
+        arrowElement.style.zIndex = options.zIndex.toString();
+        scrollMask.style.zIndex = (options.zIndex - 1).toString();
+      }
+
+      options.appendTo.appendChild(container);
+      options.appendTo.appendChild(arrowElement);
+      options.appendTo.appendChild(scrollMask);
 
       smartPosition(elements, options);
 


### PR DESCRIPTION
To correctly display popovers in ****** app we would need 2 additional options: `appendTo` and `zIndex`. 